### PR TITLE
feat: add creation endpoints for the Expense

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,18 @@
+using ExpenseTrackerGrupo2.Business.Services.Interfaces;
+using ExpenseTrackerGrupo2.DataAccess.Concretes;
+using ExpenseTrackerGrupo2.Persistence.Database;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
+builder.Services.AddControllers();
+
+builder.Services.AddScoped<IExpenseRepository, ExpenseRepository>();
+builder.Services.AddScoped<IExpenseService, ExpenseService>();
+// builder.Services.AddScoped<IDbConnectionFactory, DbConnectionFactory>();
+
+
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -15,30 +26,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-
-var summaries = new[]
-{
-    "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"
-};
-
-app.MapGet("/weatherforecast", () =>
-{
-    var forecast =  Enumerable.Range(1, 5).Select(index =>
-        new WeatherForecast
-        (
-            DateOnly.FromDateTime(DateTime.Now.AddDays(index)),
-            Random.Shared.Next(-20, 55),
-            summaries[Random.Shared.Next(summaries.Length)]
-        ))
-        .ToArray();
-    return forecast;
-})
-.WithName("GetWeatherForecast")
-.WithOpenApi();
+app.UseAuthorization();
+app.MapControllers();
 
 app.Run();
-
-record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
-{
-    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
-}

--- a/src/ExpenseTrackerGrupo2/Business/Services/Interfaces/IExpenseService.cs
+++ b/src/ExpenseTrackerGrupo2/Business/Services/Interfaces/IExpenseService.cs
@@ -9,6 +9,7 @@ public interface IExpenseService
     Task<IList<Expense>> GetAllExpenses();
     Task<Expense> GetExpenseById(Guid expenseId);
     Task<int> CreateExpense(ExpenseCreateRequest expense);
-    Task<int> UpdateExpense(ExpenseUpdateRequest expense);
+    Task<int> UpdateExpense(Guid id, ExpenseUpdateRequest expense);
     Task<bool> DeleteExpense(Guid expenseId);
+    Task<IList<Expense>> GetExpenses(DateTime? startDate, DateTime? endDate, string? category);
 }

--- a/src/ExpenseTrackerGrupo2/Controllers/ExpenseController.cs
+++ b/src/ExpenseTrackerGrupo2/Controllers/ExpenseController.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace ExpenseTrackerGrupo2.Controllers;
 
 [ApiController]
-[Route("api/expenses")]
+[Route("api/v1/expenses")]
 public class ExpenseController : ControllerBase
 {
     private readonly IExpenseService _expenseService;
@@ -19,6 +19,11 @@ public class ExpenseController : ControllerBase
     [HttpPost]
     public async Task<IActionResult> CreateExpense([FromBody] ExpenseCreateRequest request)
     {
+        if (request == null)
+        {
+            return BadRequest("Request body cannot be null.");
+        }
+
         if (!ModelState.IsValid)
         {
             return BadRequest(ModelState);
@@ -26,11 +31,11 @@ public class ExpenseController : ControllerBase
 
         try
         {
-            var result = await _expenseService.CreateExpense(request);
+            var createdExpense = await _expenseService.CreateExpense(request);
 
-            if (result > 0)
+            if (createdExpense > 0)
             {
-                return CreatedAtAction(nameof(GetExpenseById), request);
+                return CreatedAtAction(nameof(GetExpenseById), new { id = createdExpense }, createdExpense);
             }
 
             return StatusCode(500, "An error occurred while creating the expense.");
@@ -66,8 +71,8 @@ public class ExpenseController : ControllerBase
 
     [HttpGet]
     public async Task<IActionResult> GetExpenses(
-                                                 [FromQuery] DateTime? startDate, 
-                                                 [FromQuery] DateTime? endDate, 
+                                                 [FromQuery] DateTime? startDate,
+                                                 [FromQuery] DateTime? endDate,
                                                  [FromQuery] string? category
                                                  )
     {
@@ -91,6 +96,16 @@ public class ExpenseController : ControllerBase
     [HttpPut("{id}")]
     public async Task<IActionResult> UpdateExpense(Guid id, [FromBody] ExpenseUpdateRequest request)
     {
+        if (id == Guid.Empty)
+        {
+            return BadRequest("Invalid ID format.");
+        }
+
+        if (request == null)
+        {
+            return BadRequest("Request body cannot be null.");
+        }
+
         if (!ModelState.IsValid)
         {
             return BadRequest(ModelState);

--- a/src/ExpenseTrackerGrupo2/Controllers/ExpenseController.cs
+++ b/src/ExpenseTrackerGrupo2/Controllers/ExpenseController.cs
@@ -1,6 +1,138 @@
+using ExpenseTrackerGrupo2.Business.Services.Interfaces;
+using ExpenseTrackerGrupo2.Business.Services.Mappers.Requests.Expenses;
+
+using Microsoft.AspNetCore.Mvc;
+
 namespace ExpenseTrackerGrupo2.Controllers;
 
-public class ExpenseController
+[ApiController]
+[Route("api/expenses")]
+public class ExpenseController : ControllerBase
 {
+    private readonly IExpenseService _expenseService;
 
+    public ExpenseController(IExpenseService expenseService)
+    {
+        _expenseService = expenseService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateExpense([FromBody] ExpenseCreateRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        try
+        {
+            var result = await _expenseService.CreateExpense(request);
+
+            if (result > 0)
+            {
+                return CreatedAtAction(nameof(GetExpenseById), request);
+            }
+
+            return StatusCode(500, "An error occurred while creating the expense.");
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"An error occurred: {ex.Message}");
+        }
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetExpenseById(Guid id)
+    {
+        try
+        {
+            if (id == Guid.Empty)
+            {
+                return BadRequest("Invalid ID format.");
+            }
+
+            var expense = await _expenseService.GetExpenseById(id);
+            if (expense == null)
+            {
+                return NotFound($"Expense with ID {id} not found.");
+            }
+            return Ok(expense);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"An error occurred: {ex.Message}");
+        }
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetExpenses(
+                                                 [FromQuery] DateTime? startDate, 
+                                                 [FromQuery] DateTime? endDate, 
+                                                 [FromQuery] string? category
+                                                 )
+    {
+        try
+        {
+            var expenses = await _expenseService.GetExpenses(startDate, endDate, category);
+
+            if (expenses == null || !expenses.Any())
+            {
+                return NotFound("No expenses found matching the criteria.");
+            }
+
+            return Ok(expenses);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"An error occurred: {ex.Message}");
+        }
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateExpense(Guid id, [FromBody] ExpenseUpdateRequest request)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        try
+        {
+            var updatedExpense = await _expenseService.UpdateExpense(id, request);
+            return Ok(updatedExpense);
+        }
+        catch (KeyNotFoundException ex)
+        {
+            return NotFound(ex.Message);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"An error occurred: {ex.Message}");
+        }
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteExpense(Guid id)
+    {
+        if (id == Guid.Empty)
+        {
+            return BadRequest("Invalid ID format.");
+        }
+
+        try
+        {
+            var deleted = await _expenseService.DeleteExpense(id);
+
+            if (!deleted)
+            {
+                return NotFound($"Expense with ID {id} not found.");
+            }
+
+            return NoContent();
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(500, $"An error occurred: {ex.Message}");
+        }
+    }
 }

--- a/src/ExpenseTrackerGrupo2/Services/ExpenseService.cs
+++ b/src/ExpenseTrackerGrupo2/Services/ExpenseService.cs
@@ -73,13 +73,44 @@ public class ExpenseService : IExpenseService
         }
     }
 
-    public async Task<int> UpdateExpense(ExpenseUpdateRequest expense)
+    public async Task<IList<Expense>> GetExpenses(DateTime? startDate, DateTime? endDate, string? category)
+    {
+        var expenses = await _expenseRepository.GetAll();
+
+        if (startDate.HasValue)
+        {
+            expenses = expenses.Where(e => e.Date >= startDate.Value).ToList();
+        }
+
+        if (endDate.HasValue)
+        {
+            expenses = expenses.Where(e => e.Date <= endDate.Value).ToList();
+        }
+
+        if (!string.IsNullOrEmpty(category))
+        {
+            expenses = expenses.Where(e => e.Category == category).ToList();
+        }
+
+        return expenses;
+    }
+
+    public async Task<int> UpdateExpense(Guid id, ExpenseUpdateRequest expense)
     {
         try
         {
-            var expenseModel = expense.ToModel();
-            var response = await _expenseRepository.Update(expenseModel);
-            return response;
+            var existingExpense = await _expenseRepository.GetById(id);
+
+            if (existingExpense == null)
+            {
+                throw new KeyNotFoundException($"Expense with ID {id} not found.");
+            }
+            else
+            {
+                var expenseModel = expense.ToModel();
+                var response = await _expenseRepository.Update(expenseModel);
+                return response;
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Trello Ticket

[ID-01](https://trello.com/c/O2qQloui)

## What did I do?

Implemented several endpoints to manage expense records. This includes:

- A `POST /api/expenses` endpoint to allow users to record a new expense, including details such as amount, description, category, date.
- A `GET /api/expenses` endpoint to retrieve all expenses recorded for the authenticated user, you can also view them by start date end date and by category, these are not mandatory as if you don't put any of them then everything will be displayed.
- A `GET /api/expenses/{id}` endpoint to get a single expense by its ID.
- A `PUT /api/expenses/{id}` endpoint to update an existing expense.
- A `DELETE /api/expenses/{id}` endpoint to delete an expense by its ID.

All interactions with the database are handled with Dapper.

## Why did I do this?

These changes were made so that the user has the ability to perform these queries such as log, get (either all or whatever the user wants), modify and delete expense records to track them. Also as developers it will help us so that we can also do these queries.

## How did I do it?

I created several new API endpoints (`POST`, `GET`, `PUT` and `DELETE`) to handle revenue records. The steps involved were:

1. Implement the database operations using Dapper to ensure efficient queries and updates to the PostgreSQL database.
2. Create appropriate response messages for success, validation errors and authorization failures.
3. Ensure that all operations are tested with tools such as Postman and Swagger to check their functionality and error handling.

## Notes:

- Some validations were added but these validations will be done in conjunction with fluentvalidation so it is not being done in this US.
- If you are testing through Swagger this would be your website link:
```
http://localhost:5149/swagger/index.html
```
But if you are testing from Postman or another platform you could use this URL:
```
http://localhost:5149/api/expenses
```
You can change it according to what you need